### PR TITLE
31 when use existing constructor code remove redundant white spaces between params type and name

### DIFF
--- a/src/main/java/com/aggregated/BuildAnnotatableCodePhase.java
+++ b/src/main/java/com/aggregated/BuildAnnotatableCodePhase.java
@@ -24,6 +24,7 @@ public class BuildAnnotatableCodePhase extends BaseConstructorPhaseAlgorithm {
   private static final String COMMENT_BLOCK = "/*";
   private static final String AT = "@";
   private static final String SKIP_MARKER = "SKIP";
+  private static final Set<Character> PARAM_BASED_CHARACTERS = new HashSet<>();
   private static final String WEIRD_FIELD = "this$";
   private static final String CONSTRUCTOR_BODY = "CONSTRUCTOR_BODY";
   private static final String DECLARED_FIELDS = "DECLARED_FIELDS";
@@ -54,6 +55,11 @@ public class BuildAnnotatableCodePhase extends BaseConstructorPhaseAlgorithm {
           "java.net",
           "java.util.concurrent"
   );
+  static {
+    PARAM_BASED_CHARACTERS.add(',');
+    PARAM_BASED_CHARACTERS.add('<');
+    PARAM_BASED_CHARACTERS.add('>');
+  }
   /**
    * This flag controls
    * if custom annotation is added
@@ -1182,7 +1188,7 @@ public class BuildAnnotatableCodePhase extends BaseConstructorPhaseAlgorithm {
         if (stimulatedSyntaxStack > 0) {
           toReverse.append(cur);
         } else {
-          String cleansed = StringUtils.stripDoubleEndedNonAlphaNumeric(toReverse.reverse().toString());
+          String cleansed = StringUtils.ensureOneWhitespace(toReverse.reverse().toString(), PARAM_BASED_CHARACTERS);
           if (isPreserveOrder) {
             stack.push(cleansed);
           } else {
@@ -1199,7 +1205,7 @@ public class BuildAnnotatableCodePhase extends BaseConstructorPhaseAlgorithm {
       }
       toReverse.append(cur);
     }
-    String last = StringUtils.stripDoubleEndedNonAlphaNumeric(toReverse.reverse().toString());
+    String last = StringUtils.ensureOneWhitespace(toReverse.reverse().toString(), PARAM_BASED_CHARACTERS);
     if (isPreserveOrder) {
       stack.push(last);
       while (!stack.isEmpty()) {

--- a/src/main/java/com/aggregated/StringUtils.java
+++ b/src/main/java/com/aggregated/StringUtils.java
@@ -42,6 +42,9 @@ public class StringUtils {
     }
     return false;
   }
+  public static boolean isBlank(String inp) {
+    return !isNoneBlank(inp);
+  }
 
   public static boolean containsAny(String toCheck, String... args) {
     for (String each : args) {
@@ -555,6 +558,36 @@ public class StringUtils {
       return false;
     }
     return true;
+  }
+
+  /**
+   * We only consume letter / digit character, except given characters.
+   * This will apply #stripDoubleEndedNonAlphaNumeric's logic,
+   * and also ensure each pair of consecutive characters are only one-spaced separated.
+   * @param inp
+   * @return
+   */
+  public static String ensureOneWhitespace(String inp, Set<Character> consumable) {
+    if (StringUtils.isEmpty(inp) || StringUtils.isBlank(inp)) {
+      return "";
+    }
+    StringBuilder runner = new StringBuilder();
+    boolean isMetSpace = false;
+    for (int i = 0, n = inp.length(); i < n; i++) {
+      Character c = inp.charAt(i);
+      if (Character.isLetterOrDigit(c) || consumable.contains(c)) {
+        runner.append(c);
+        isMetSpace = false;
+        continue;
+      }
+      if (Character.isSpaceChar(c)) {
+        if (i > 0 && !isMetSpace && runner.length() > 0) {
+          runner.append(c);
+          isMetSpace = true;
+        }
+      }
+    }
+    return runner.toString();
   }
 }
 

--- a/src/main/java/com/aggregated/inline_tests/intricate_tests/existing_ctor_test/hierarchical_test/BaseClass.java
+++ b/src/main/java/com/aggregated/inline_tests/intricate_tests/existing_ctor_test/hierarchical_test/BaseClass.java
@@ -23,7 +23,8 @@ public abstract class BaseClass<T> {
     private List<DummyObject> listDummy;
     private Map<String, HelloIImAnotherDummy> ok;
     protected BaseClass(){}
-    BaseClass(Integer x, String paramText, boolean y, Map<String, Map<String, Map<SortedSet<Integer>, String>>> amIScary, Map<String, Map<String, Map<SortedSet<Integer>, DummyObject02>>> amIScary02, DummyObject01 dummyObject01, DummyObject dummyObject, Collection<DummyObject> listDummy, Map<String, HelloIImAnotherDummy> ok) {
+
+    BaseClass(Integer x, String paramText, boolean y, Map<String, Map<String, Map<SortedSet<Integer>, String>>> amIScary, Map<String, Map<String, Map<SortedSet<Integer>, DummyObject02>>> amIScary02, DummyObject01 dummyObject01, DummyObject     dummyObject, Collection<DummyObject>    listDummy, Map<String, HelloIImAnotherDummy>    ok) {
         if (listDummy.size() == 0) {
             this.listDummy = Collections.emptyList();
         } else {


### PR DESCRIPTION
After image 1:
<img width="1061" alt="image" src="https://github.com/trgpnt/Java-Class-Annotatable-Constructor-Templater/assets/130839027/cef198fd-beef-4a63-8021-bf723fd97673">
After image 2 :
<img width="981" alt="image" src="https://github.com/trgpnt/Java-Class-Annotatable-Constructor-Templater/assets/130839027/1efa3bc3-a92c-4eab-ad5d-e80f1a5ed87f">
